### PR TITLE
Fix/playsong, follow, playlistpage

### DIFF
--- a/src/components/AddPlaylist/AddPlaylist.tsx
+++ b/src/components/AddPlaylist/AddPlaylist.tsx
@@ -25,13 +25,10 @@ const AddPlaylist = () => {
     };
 
     const createPlaylist = async () => {
-        try {
             const promise = await dispatch(playlistsAsyncActions.createPlaylist(name));
-            history.push(`playlist/${promise.payload}`)
-        } catch (error) {
-            return
-        }
-
+            if (promise.payload !== 'database_error') {
+                history.push(`playlist/${promise.payload}`)
+            }
     } 
 
     const submit = (event: FormEvent<HTMLButtonElement>) => {

--- a/src/components/AddPlaylist/AddPlaylist.tsx
+++ b/src/components/AddPlaylist/AddPlaylist.tsx
@@ -1,10 +1,7 @@
 import React, { ChangeEvent, FormEvent, useState } from "react";
-import { useSelector } from "react-redux";
 import { useDispatch } from "react-redux";
 import {useHistory} from "react-router-dom";
-import { selectCurrentPlaylist } from "../../store/slices/playlists/selectors";
 import { playlistsAsyncActions } from "../../store/slices/playlists/slice";
-import Playlist from "../../types/Playlist";
 import { Button, Container, FormWrapper, HelperText, StyledInput, Title } from "./styles";
 
 const AddPlaylist = () => {

--- a/src/components/FollowPlaylist/FollowPlaylist.test.tsx
+++ b/src/components/FollowPlaylist/FollowPlaylist.test.tsx
@@ -11,8 +11,8 @@ import userEvent from "@testing-library/user-event";
 const mockStore = configureMockStore([thunk]);
 const store = mockStore({
     playlists: {
-        ownPlaylists: null,
-        otherPlaylists: null,
+        ownPlaylists: [],
+        otherPlaylists: [],
         currentPlaylist: {
             id: "fake_playlist_id",
             playlistName: "My cool playlist",
@@ -110,7 +110,7 @@ describe("FollowPlaylist component", () => {
         const actions = store.getActions();
         expect(actions[0]).toBeUndefined();
     });
-it("does not dispatch action when helper text is null, but id is empty and button is clicked", async () => {
+    it("does not dispatch action when helper text is null, but id is empty and button is clicked", async () => {
         const { getByTestId } = render(
             <ThemeProvider theme={theme}>
                 <Provider store={store}>

--- a/src/components/FollowPlaylist/FollowPlaylist.tsx
+++ b/src/components/FollowPlaylist/FollowPlaylist.tsx
@@ -1,10 +1,12 @@
 import React, { ChangeEvent, FormEvent, useState } from "react";
-import { useDispatch } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 import { useHistory } from "react-router-dom";
+import { selectOwnPlaylistIds } from "../../store/slices/playlists/selectors";
 import { playlistsAsyncActions } from "../../store/slices/playlists/slice";
 import { Button, Container, FormWrapper, HelperText, StyledInput, Title, Wrapper } from "./styles";
 
 const FollowPlaylist = () => {
+    const ownPlaylistIds = useSelector(selectOwnPlaylistIds);
     const [id, setId] = useState<string>("");
     const [helperText, setHelperText] = useState<string | null>(null);
     const dispatch = useDispatch();
@@ -48,6 +50,12 @@ const FollowPlaylist = () => {
             setHelperText("The playlist Id must be 20 character long!")
             return;
         }
+        
+        if (ownPlaylistIds.includes(id)) {
+            setHelperText("You cannot follow your own playlist!")
+            return;
+        }
+
         setId("");
         followPlaylist();
 

--- a/src/components/FollowPlaylist/FollowPlaylist.tsx
+++ b/src/components/FollowPlaylist/FollowPlaylist.tsx
@@ -28,14 +28,12 @@ const FollowPlaylist = () => {
 
 
     const followPlaylist = async () => {
-        try {
-            await dispatch(playlistsAsyncActions.followPlaylist(id));
+        const result = await dispatch(playlistsAsyncActions.followPlaylist(id));
+        if (result.payload === 'playlist_followed'){
             history.push(`/playlist/${id}`)
-        } catch (error) {
-            return
         }
-
     } 
+
     const submit = (event: FormEvent<HTMLButtonElement>) => {
         event.preventDefault();
         if (helperText) {

--- a/src/components/PlaySongs/PlaySongs.tsx
+++ b/src/components/PlaySongs/PlaySongs.tsx
@@ -9,12 +9,13 @@ import PauseIcon from "@material-ui/icons/PauseRounded";
 import StopIcon from "@material-ui/icons/StopRounded";
 import VolumeUpIcon from "@material-ui/icons/VolumeUpRounded";
 import VolumeOffIcon from "@material-ui/icons/VolumeOffRounded";
-import { selectSongs } from "../../store/slices/playlists/selectors";
+import { selectCurrentPlaylist, selectSongs } from "../../store/slices/playlists/selectors";
 import { Container, ControlWrapper, Title, ButtonCanBeDisabled, YoutubeWrapper, Button, PlaybackButton } from "./styles";
 import Song from "../../types/Song";
 
 const PlaySongs = () => {
     const songs = useSelector(selectSongs);
+    const currentPlaylist = useSelector(selectCurrentPlaylist);
     const [playbackStarted, setPlaybackStarted] = useState<boolean>(false);
     const [player, setPlayer] = useState<any | undefined>();
     const [currentSong, setCurrentSong] = useState<Song | undefined>();
@@ -36,6 +37,9 @@ const PlaySongs = () => {
 
     const startPlayback = () => {
         setPlaybackStarted(true);
+        if (songs.length === 1) {
+            setCanSkipForward(false)
+        }
     };
 
     const onReady = (event: any) => {
@@ -128,6 +132,10 @@ const PlaySongs = () => {
 
         setCanChangeSong(false);
     }, [songs, currentSongForwardIndex, currentSongBackwardIndex, canChangeSong, playedSongs]);
+
+    useEffect(() => {
+        setPlaybackStarted(false)
+    }, [currentPlaylist && currentPlaylist.id])
 
     if (!playbackStarted) {
         return (

--- a/src/components/PlaySongs/PlaySongs.tsx
+++ b/src/components/PlaySongs/PlaySongs.tsx
@@ -135,7 +135,7 @@ const PlaySongs = () => {
 
     useEffect(() => {
         setPlaybackStarted(false)
-    }, [currentPlaylist && currentPlaylist.id])
+    }, [currentPlaylist.id])
 
     if (!playbackStarted) {
         return (

--- a/src/components/PlaylistPage/PlaylistPage.tsx
+++ b/src/components/PlaylistPage/PlaylistPage.tsx
@@ -46,7 +46,7 @@ if (currentPlaylist && currentUser && (currentPlaylist.owner !== currentUser.id)
 return (
         <Container>
             {currentPlaylist && <Title> {currentPlaylist.playlistName} </Title>}
-            <PlaySongs/>
+            {currentPlaylist && currentPlaylist.songs && currentPlaylist.songs.length > 0 && <PlaySongs/>}
             <AddSong />
             <Songlist />
         </Container>

--- a/src/components/PlaylistPage/PlaylistPage.tsx
+++ b/src/components/PlaylistPage/PlaylistPage.tsx
@@ -6,7 +6,7 @@ import { selectCurrentPlaylist } from "../../store/slices/playlists/selectors";
 import { playlistsAsyncActions } from "../../store/slices/playlists/slice";
 import AddSong from "../AddSong";
 import PlaySongs from "../PlaySongs";
-import { Button, Container, Title } from "./styles";
+import { Button, Container, Subtitle, Title } from "./styles";
 import Songlist from "../Songlist";
 
 const PlaylistPage = () => {
@@ -46,6 +46,7 @@ if (currentPlaylist && currentUser && (currentPlaylist.owner !== currentUser.id)
 return (
         <Container>
             {currentPlaylist && <Title> {currentPlaylist.playlistName} </Title>}
+            {currentPlaylist && <Subtitle> Playlist Id: {currentPlaylist.id} </Subtitle>}
             {currentPlaylist && currentPlaylist.songs && currentPlaylist.songs.length > 0 && <PlaySongs/>}
             <AddSong />
             <Songlist />

--- a/src/components/PlaylistPage/styles.ts
+++ b/src/components/PlaylistPage/styles.ts
@@ -16,6 +16,12 @@ export const Title = styled.div`
     margin-bottom: 3rem;
 `
 
+export const Subtitle = styled.div`
+    color: ${({ theme }) => theme.colors.lightGreen};
+    font-size: 0.8rem;
+    margin-bottom: 0.5rem;
+`
+
 export const Button = styled.button`
     border-radius: 5px;
     border-width: 0px;

--- a/src/store/slices/playlists/selectors.ts
+++ b/src/store/slices/playlists/selectors.ts
@@ -1,6 +1,7 @@
 import RootState from '../../RootState'
 
 export const selectOwnPlaylists = (state: RootState) => state.playlists.ownPlaylists
+export const selectOwnPlaylistIds = (state: RootState) => state.playlists.ownPlaylists?.map((playlist) => playlist.id)
 export const selectOtherPlaylists = (state: RootState) => state.playlists.otherPlaylists
 export const selectCurrentPlaylist = (state: RootState) => state.playlists.currentPlaylist
 export const selectSongs = (state: RootState) => state.playlists.currentPlaylist?.songs

--- a/src/store/slices/playlists/slice.test.ts
+++ b/src/store/slices/playlists/slice.test.ts
@@ -334,17 +334,21 @@ describe('FollowPlaylist slice async action', () => {
   beforeEach(() => {
       store.clearActions()
 })
-  it('returns the right actions if the playlist is followed', async () => {
+  it('returns the right action if the playlist is followed', async () => {
     mockedFirestoreApi.getPlaylistDetails.mockResolvedValueOnce({ownerName: "fake_player", playlistName:"Cool playlist"})
     mockedFirestoreApi.followPlaylist.mockResolvedValueOnce()
-    mockedFirestoreApi.subscribeToPlaylist.mockResolvedValueOnce()
-    mockedFirestoreApi.subscribeToSongsCollection.mockResolvedValueOnce()
     await store.dispatch(playlistsAsyncActions.followPlaylist("fake_playlistId"))
 
     const actions = store.getActions()
-    expect(actions[1].type).toEqual('playlists/subscribeToPlaylist/pending')
-    expect(actions[2].type).toEqual('playlists/subscribeToSongsCollection/pending')
-    expect(actions[3].type).toEqual('playlists/followPlaylist/fulfilled')
+    expect(actions[1].type).toEqual('playlists/followPlaylist/fulfilled')
+  })
+  it('returns error action if there is no such playlist', async () => {
+    mockedFirestoreApi.getPlaylistDetails.mockResolvedValueOnce(undefined)
+    await store.dispatch(playlistsAsyncActions.followPlaylist("fake_playlistId"))
+
+    const actions = store.getActions()
+    expect(actions[1].type).toEqual('playlists/followPlaylist/rejected')
+    expect(actions[1].payload).toEqual('no_such_playlist')
   })
   it('returns error action if the database is down', async () => {
     mockedFirestoreApi.getPlaylistDetails.mockRejectedValueOnce("database down")
@@ -360,16 +364,12 @@ describe('UnfollowPlaylist slice async action', () => {
   beforeEach(() => {
       store.clearActions()
 })
-  it('returns the right actions if the playlist is unfollowed', async () => {
+  it('returns the right action if the playlist is unfollowed', async () => {
     mockedFirestoreApi.unfollowPlaylist.mockResolvedValueOnce()
-    mockedFirestoreApi.unsubscribeFromPlaylist.mockResolvedValueOnce()
-    mockedFirestoreApi.unsubscribeFromSongsCollection.mockResolvedValueOnce()
     await store.dispatch(playlistsAsyncActions.unfollowPlaylist("fake_playlistId"))
 
     const actions = store.getActions()
-    expect(actions[1].type).toEqual('playlists/unsubscribeFromPlaylist/pending')
-    expect(actions[2].type).toEqual('playlists/unsubscribeFromSongsCollection/pending')
-    expect(actions[3].type).toEqual('playlists/unfollowPlaylist/fulfilled')
+    expect(actions[1].type).toEqual('playlists/unfollowPlaylist/fulfilled')
   })
   it('returns error action if the database is down', async () => {
     mockedFirestoreApi.unfollowPlaylist.mockRejectedValueOnce("database down")

--- a/src/store/slices/playlists/slice.ts
+++ b/src/store/slices/playlists/slice.ts
@@ -139,10 +139,11 @@ string,
         const playlistId = payload
         try {
             const playlistDetails: any = await firestoreApi.getPlaylistDetails(playlistId)
+            if (!playlistDetails) {
+                return thunkApi.rejectWithValue('no_such_playlist')
+            }
             const {ownerName, playlistName } = playlistDetails
             await firestoreApi.followPlaylist(currentUser!.id, ownerName, playlistId, playlistName)
-            thunkApi.dispatch(subscribeToPlaylist(playlistId))
-            thunkApi.dispatch(subscribeToSongsCollection(playlistId))
             return 'playlist_followed'
         } catch (error) {
             return thunkApi.rejectWithValue('database_error')
@@ -162,8 +163,6 @@ const unfollowPlaylist = createAsyncThunk<
             const playlistId = payload
             try {
                 await firestoreApi.unfollowPlaylist(currentUser!.id, playlistId)
-                thunkApi.dispatch(unsubscribeFromPlaylist(playlistId))
-                thunkApi.dispatch(unsubscribeFromSongsCollection(playlistId))
                 return 'playlist_unfollowed'
             } catch (error) {
                 return thunkApi.rejectWithValue('database_error')


### PR DESCRIPTION
Added/ fixed:

* only show listen to songs button if there are songs in the playlist
* disable skipforward button if there is only one song
* stop playback when switching to another playlist
* show playlist Id for own playlists
* cannot follow own playlist
* fix error handling in FollowPlaylist and AddPlaylist components 
* delete unnecessary calls from follow, unfollow async actions